### PR TITLE
Concatenation of Arrays

### DIFF
--- a/src/add_two_integers.rs
+++ b/src/add_two_integers.rs
@@ -1,5 +1,7 @@
+// https://leetcode.com/problems/add-two-integers/
+
 impl Solution {
     pub fn sum(num1: i32, num2: i32) -> i32 {
-        return num1 + num2;
+        return num1 + num2; // this does not overflow i32 because of the constraints: -100<= nums1,nums2 <= 100
     }
 }

--- a/src/concatenation_arrays.rs
+++ b/src/concatenation_arrays.rs
@@ -1,10 +1,10 @@
 // https://leetcode.com/problems/concatenation-of-array/
 impl Solution {
-    pub fn get_concatenation(nums: Vec<i32>) -> Vec<i32> {
+    pub fn get_concatenation(mut nums: Vec<i32>) -> Vec<i32> {
         let n = nums.len();
-        let mut res: Vec<i32> = Vec::with_capacity(2 * n); // create with 2n capacity
-        res.extend(&nums);
-        res.extend(&nums);
-        return res;
+        for i in 0..n {
+            nums.push(nums[i]);
+        }
+        return nums;
     }
 }

--- a/src/concatenation_arrays.rs
+++ b/src/concatenation_arrays.rs
@@ -1,10 +1,7 @@
 // https://leetcode.com/problems/concatenation-of-array/
 impl Solution {
     pub fn get_concatenation(mut nums: Vec<i32>) -> Vec<i32> {
-        let n = nums.len();
-        for i in 0..n {
-            nums.push(nums[i]);
-        }
-        return nums;
+        nums.extend_from_within(..);
+        nums
     }
 }

--- a/src/concatenation_arrays.rs
+++ b/src/concatenation_arrays.rs
@@ -1,7 +1,14 @@
 // https://leetcode.com/problems/concatenation-of-array/
-impl Solution {
-    pub fn get_concatenation(mut nums: Vec<i32>) -> Vec<i32> {
-        nums.extend_from_within(..);
-        nums
-    }
+
+pub fn get_concatenation(mut nums: Vec<i32>) -> Vec<i32> {
+    nums.extend_from_within(..);
+    nums
+}
+
+#[test]
+fn test_get_concatenation() {
+    let input: Vec<i32> = [1, 2, 3, 4, 5].into();
+    let expected: Vec<i32> = [1, 2, 3, 4, 5, 1, 2, 3, 4, 5].into();
+    let result = get_concatenation(input);
+    assert_eq!(expected, result);
 }

--- a/src/concatenation_arrays.rs
+++ b/src/concatenation_arrays.rs
@@ -1,0 +1,10 @@
+// https://leetcode.com/problems/concatenation-of-array/
+impl Solution {
+    pub fn get_concatenation(nums: Vec<i32>) -> Vec<i32> {
+        let n = nums.len();
+        let mut res: Vec<i32> = Vec::with_capacity(2 * n); // create with 2n capacity
+        res.extend(&nums);
+        res.extend(&nums);
+        return res;
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod concatenation_arrays;
+
 fn main() {
     println!("Hello, world!");
     // Rust strings use the least amount of bytes possible to represent its chars


### PR DESCRIPTION
This PR:
- fixes #3: 
simplified `get_concatenation` by using `vec::extend_from_within` instead of `for` loop.
- fixes #2: 
added a unit test `test_get_concatenation` with `#[test]` attribute and modified `main.rs` to include `mod concatenation_arrays` so that it can be run with `cargo test`
